### PR TITLE
Added more queries and modified the test script to actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ Note the public exposure of the logs on persistent storage. It is a good practic
 a safe location. If the service has to change, the logs are kept for future problem resolution.
 
 
+## Testing:
+
+To run tests, go to the `test-suite.sh` file and edit the **remote_ip** variable with the server ip where the nginx & virtuoso containers are running. Then just execute `./test-suite.sh`.
+
+To add more queries, just edit the `queries.txt` file. Don't forget to add a newline after the last query or it won't be executed.
+

--- a/test/queries.txt
+++ b/test/queries.txt
@@ -2,4 +2,8 @@ select distinct ?s where { ?s ?p ?o. ?p a ?pt. ?o a ?ot. } LIMIT 1000
 select distinct ?p where { ?s ?p ?o . } LIMIT 50000
 select distinct ?p where { ?s ?p ?o . } LIMIT 100000
 select distinct ?p where { ?s ?p ?o . } LIMIT 200000
-select distinct count(?o) where { ?s a ?o . } order by ?s
+select distinct ?name ?street ?pcode where { ?organization gr:legalName ?name ; vcard2006:hasAddress ?address . ?address vcard2006:street-address ?street ; vcard2006:postal-code ?pcode . }
+PREFIX vcard2006: <http://www.w3.org/2006/vcard/ns#> PREFIX elodGeo: <http://linkedeconomy.org/geoOntology#> SELECT DISTINCT ?pcode ?nameMunicipality WHERE { ?organization vcard2006:hasAddress ?address . ?address vcard2006:postal-code ?pcode. ?codeArea elodGeo:postalCode ?pcode . ?municipality elodGeo:hasPart ?codeArea ; elodGeo:name ?nameMunicipality . filter langMatches(lang(?nameMunicipality),'en') }
+SELECT distinct * WHERE { ?s rdfs:subClassOf ?p }
+prefix qb:<http://purl.org/linked-data/cube#> select distinct ?p ?o from <http://yourdatastories.eu/Diavgeia/DataCube> where { ?s a qb:Observation ; ?p ?o }
+select distinct ?sector ?label (count(distinct ?project) as ?count) where { ?project elod:sector ?sector . ?sector skos:prefLabel ?label }

--- a/test/queries.txt
+++ b/test/queries.txt
@@ -1,7 +1,5 @@
-select distinct ?p where {?s ?p ?o} LIMIT 1000
-select distinct ?p where {?s ?p ?o} LIMIT 5000
-select distinct ?p where {?s ?p ?o} LIMIT 10000
-select distinct ?p where {?s ?p ?o} LIMIT 25000
-select distinct ?p where {?s ?p ?o} LIMIT 50000
-select distinct ?p where {?s ?p ?o} LIMIT 100000
-select distinct ?p where {?s ?p ?o} LIMIT 200000
+select distinct ?s where { ?s ?p ?o. ?p a ?pt. ?o a ?ot. } LIMIT 1000
+select distinct ?p where { ?s ?p ?o . } LIMIT 50000
+select distinct ?p where { ?s ?p ?o . } LIMIT 100000
+select distinct ?p where { ?s ?p ?o . } LIMIT 200000
+select distinct count(?o) where { ?s a ?o . } order by ?s

--- a/test/queries.txt
+++ b/test/queries.txt
@@ -2,6 +2,10 @@ select distinct ?s where { ?s ?p ?o. ?p a ?pt. ?o a ?ot. } LIMIT 1000
 select distinct ?p where { ?s ?p ?o . } LIMIT 50000
 select distinct ?p where { ?s ?p ?o . } LIMIT 100000
 select distinct ?p where { ?s ?p ?o . } LIMIT 200000
+select distinct ?p where { ?s ?p ?o . } LIMIT 500000
+select distinct ?s count(?o) where { ?s a ?o . } group by ?s LIMIT 1000
+select distinct ?s count(?o) where { ?s a ?o . } group by ?s LIMIT 5000
+select distinct ?s count(?o) where { ?s a ?o . } group by ?s LIMIT 10000
 select distinct ?name ?street ?pcode where { ?organization gr:legalName ?name ; vcard2006:hasAddress ?address . ?address vcard2006:street-address ?street ; vcard2006:postal-code ?pcode . }
 PREFIX vcard2006: <http://www.w3.org/2006/vcard/ns#> PREFIX elodGeo: <http://linkedeconomy.org/geoOntology#> SELECT DISTINCT ?pcode ?nameMunicipality WHERE { ?organization vcard2006:hasAddress ?address . ?address vcard2006:postal-code ?pcode. ?codeArea elodGeo:postalCode ?pcode . ?municipality elodGeo:hasPart ?codeArea ; elodGeo:name ?nameMunicipality . filter langMatches(lang(?nameMunicipality),'en') }
 SELECT distinct * WHERE { ?s rdfs:subClassOf ?p }

--- a/test/queries.txt
+++ b/test/queries.txt
@@ -1,0 +1,7 @@
+select distinct ?p where {?s ?p ?o} LIMIT 1000
+select distinct ?p where {?s ?p ?o} LIMIT 5000
+select distinct ?p where {?s ?p ?o} LIMIT 10000
+select distinct ?p where {?s ?p ?o} LIMIT 25000
+select distinct ?p where {?s ?p ?o} LIMIT 50000
+select distinct ?p where {?s ?p ?o} LIMIT 100000
+select distinct ?p where {?s ?p ?o} LIMIT 200000

--- a/test/test-suite.sh
+++ b/test/test-suite.sh
@@ -17,14 +17,14 @@ echo -e "${RED}REMOTE VIRTUOSO PROXY: ${GREEN} ${virtuoso_url}${NC}"
 
 while read query; do
     echo -e "${PURPLE}query: ${YELLOW} ${query}${NC}" 
-    nginxtime=$(TIMEFORMAT=%R; time (for i in {1..10}; do curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query='${query}' ${nginx_url} > /dev/null; sleep 0.5; done) 2>&1 1>/dev/null)
-    virtuosotime=$(TIMEFORMAT=%R; time (for i in {1..10; do curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query='${query}' ${virtuoso_url} > /dev/null; sleep 0.5; done) 2>&1 1>/dev/null)
+    nginxtime=$(TIMEFORMAT=%R; time (for i in {1..15}; do curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query='${query}' ${nginx_url} > /dev/null; sleep 0.5; done) 2>&1 1>/dev/null)
+    virtuosotime=$(TIMEFORMAT=%R; time (for i in {1..15}; do curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query='${query}' ${virtuoso_url} > /dev/null; sleep 0.5; done) 2>&1 1>/dev/null)
 
-    nginxavg=$(echo "scale=4; $nginxtime / 10" | bc -l)
-    virtuosoavg=$(echo "scale=4; $virtuosotime / 10" | bc -l)
+    nginxavg=$(echo "scale=4; $nginxtime / 15" | bc -l)
+    virtuosoavg=$(echo "scale=4; $virtuosotime / 15" | bc -l)
 
     decrease=$(echo "scale=4; $virtuosoavg - $nginxavg" | bc -l)
-    perc_decrease=$(echo "$decrease / $virtuosoavg * 100" | bc -l)
+    perc_decrease=$(echo "scale=4; $decrease / $virtuosoavg * 100" | bc -l)
 
     echo -e "\t${PURPLE}avg nginx proxy time (15 calls): ${YELLOW} ${nginxavg}${NC}"
     echo -e "\t${PURPLE}avg virtuoso time (15 calls): ${YELLOW} ${virtuosoavg}${NC}"

--- a/test/test-suite.sh
+++ b/test/test-suite.sh
@@ -8,27 +8,75 @@ NC='\033[0m' # No Color
 
 remote_ip=""
 remote_path="sparql"
-nginx_url="${remote_ip}:<nginx_port>/${remote_path}"
-virtuoso_url="${remote_ip}:<virtuoso_port>/${remote_path}"
+nginx_url="${remote_ip}:443/${remote_path}"
+virtuoso_url="${remote_ip}:8890/${remote_path}"
 
 
 echo -e "${RED}REMOTE NGINX PROXY: ${GREEN} ${nginx_url}${NC}"
 echo -e "${RED}REMOTE VIRTUOSO PROXY: ${GREEN} ${virtuoso_url}${NC}"
 
-while read query; do
-    echo -e "${PURPLE}query: ${YELLOW} ${query}${NC}" 
-    nginxtime=$(TIMEFORMAT=%R; time (for i in {1..15}; do curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query='${query}' ${nginx_url} > /dev/null; sleep 0.5; done) 2>&1 1>/dev/null)
-    virtuosotime=$(TIMEFORMAT=%R; time (for i in {1..15}; do curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query='${query}' ${virtuoso_url} > /dev/null; sleep 0.5; done) 2>&1 1>/dev/null)
 
-    nginxavg=$(echo "scale=4; $nginxtime / 15" | bc -l)
-    virtuosoavg=$(echo "scale=4; $virtuosotime / 15" | bc -l)
+while IFS=  read -r query
+do
+    echo -e "${PURPLE}Query: ${YELLOW}${query} to Nginx" 
+    nginx_start=$(date +%s)
+    for i in {1..10}
+    do
+        curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query="$query" $nginx_url > /dev/null
+    done
+    nginx_stop=$(date +%s)   
+    nginxavg=$(echo "scale=4; ($nginx_stop - $nginx_start) / 10" | bc -l)
+    
+    echo -e "Query: ${query} to Virtuoso"
+    virtuoso_start=$(date +%s)
+    for i in {1..10}
+    do
+        curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query="$query" $virtuoso_url > /dev/null
+    done
+    virtuoso_stop=$(date +%s)   
+    virtuosoavg=$(echo "scale=4; ($virtuoso_stop - $virtuoso_start) / 10" | bc -l)
 
     decrease=$(echo "scale=4; $virtuosoavg - $nginxavg" | bc -l)
-    perc_decrease=$(echo "scale=4; $decrease / $virtuosoavg * 100" | bc -l)
+    perc_decrease=$(echo "scale=4; $decrease / $virtuosoavg * 100" | bc -l)   
 
-    echo -e "\t${PURPLE}avg nginx proxy time (15 calls): ${YELLOW} ${nginxavg}${NC}"
-    echo -e "\t${PURPLE}avg virtuoso time (15 calls): ${YELLOW} ${virtuosoavg}${NC}"
+    echo -e "\t${PURPLE}avg nginx proxy time (10 calls): ${YELLOW} ${nginxavg}${NC}"
+    echo -e "\t${PURPLE}avg virtuoso time (10 calls): ${YELLOW} ${virtuosoavg}${NC}"
     echo -e "\t\t${PURPLE}nginx calls compared to virtuoso are ${YELLOW} ${perc_decrease} % faster. ${NC}"
-done < queries.txt
+
+done < "queries.txt"
 
 
+
+# while read query; do
+#     echo -e "${PURPLE}query: ${YELLOW} ${query}${NC}"
+
+#     nginx_start=$(date +%s)
+#     echo $nginx_start
+#     curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query="${query}" ${nginx_url} > /dev/null
+#     nginx_stop=$(date +%s)
+#     echo $nginx_stop
+#     nginxavg=$(echo "scale=4; ($nginx_stop - $nginx_start) / 3" | bc -l)
+
+#     # nginxtime=$(TIMEFORMAT=%R; time (for i in {1..15}; do curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query='${query}' ${nginx_url} > /dev/null; sleep 0.5; done) 2>&1 1>/dev/null)
+#     # virtuosotime=$(TIMEFORMAT=%R; time (for i in {1..15}; do curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query='${query}' ${virtuoso_url} > /dev/null; sleep 0.5; done) 2>&1 1>/dev/null)
+#     #
+#     # nginxavg=$(echo "scale=4; $nginxtime / 15" | bc -l)
+#     # virtuosoavg=$(echo "scale=4; $virtuosotime / 15" | bc -l)
+#     #
+#     # decrease=$(echo "scale=4; $virtuosoavg - $nginxavg" | bc -l)
+#     # perc_decrease=$(echo "scale=4; $decrease / $virtuosoavg * 100" | bc -l)
+#     #
+#     # echo -e "\t${PURPLE}avg nginx proxy time (15 calls): ${YELLOW} ${nginxavg}${NC}"
+#     # echo -e "\t${PURPLE}avg virtuoso time (15 calls): ${YELLOW} ${virtuosoavg}${NC}"
+#     # echo -e "\t\t${PURPLE}nginx calls compared to virtuoso are ${YELLOW} ${perc_decrease} % faster. ${NC}"
+
+#     # select distinct ?p where {?s ?p ?o} LIMIT 5000
+#     # select distinct ?p where {?s ?p ?o} LIMIT 10000
+#     # select distinct ?p where {?s ?p ?o} LIMIT 25000
+#     # select distinct ?p where {?s ?p ?o} LIMIT 50000
+#     # select distinct ?p where {?s ?p ?o} LIMIT 100000
+#     # select distinct ?p where {?s ?p ?o} LIMIT 200000
+#     # select distinct ?p where {?s ?p ?o} LIMIT 500000
+#     # select distinct ?p where {?s ?p ?o} LIMIT 1000000
+
+# done < queries.txt

--- a/test/test-suite.sh
+++ b/test/test-suite.sh
@@ -6,7 +6,7 @@ YELLOW='\033[1;33m'
 PURPLE='\033[1;35m'
 NC='\033[0m' # No Color
 
-remote_ip=""
+remote_ip="http://143.233.226.61"
 remote_path="sparql"
 nginx_url="${remote_ip}:443/${remote_path}"
 virtuoso_url="${remote_ip}:8890/${remote_path}"
@@ -44,39 +44,3 @@ do
     echo -e "\t\t${PURPLE}nginx calls compared to virtuoso are ${YELLOW} ${perc_decrease} % faster. ${NC}"
 
 done < "queries.txt"
-
-
-
-# while read query; do
-#     echo -e "${PURPLE}query: ${YELLOW} ${query}${NC}"
-
-#     nginx_start=$(date +%s)
-#     echo $nginx_start
-#     curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query="${query}" ${nginx_url} > /dev/null
-#     nginx_stop=$(date +%s)
-#     echo $nginx_stop
-#     nginxavg=$(echo "scale=4; ($nginx_stop - $nginx_start) / 3" | bc -l)
-
-#     # nginxtime=$(TIMEFORMAT=%R; time (for i in {1..15}; do curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query='${query}' ${nginx_url} > /dev/null; sleep 0.5; done) 2>&1 1>/dev/null)
-#     # virtuosotime=$(TIMEFORMAT=%R; time (for i in {1..15}; do curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query='${query}' ${virtuoso_url} > /dev/null; sleep 0.5; done) 2>&1 1>/dev/null)
-#     #
-#     # nginxavg=$(echo "scale=4; $nginxtime / 15" | bc -l)
-#     # virtuosoavg=$(echo "scale=4; $virtuosotime / 15" | bc -l)
-#     #
-#     # decrease=$(echo "scale=4; $virtuosoavg - $nginxavg" | bc -l)
-#     # perc_decrease=$(echo "scale=4; $decrease / $virtuosoavg * 100" | bc -l)
-#     #
-#     # echo -e "\t${PURPLE}avg nginx proxy time (15 calls): ${YELLOW} ${nginxavg}${NC}"
-#     # echo -e "\t${PURPLE}avg virtuoso time (15 calls): ${YELLOW} ${virtuosoavg}${NC}"
-#     # echo -e "\t\t${PURPLE}nginx calls compared to virtuoso are ${YELLOW} ${perc_decrease} % faster. ${NC}"
-
-#     # select distinct ?p where {?s ?p ?o} LIMIT 5000
-#     # select distinct ?p where {?s ?p ?o} LIMIT 10000
-#     # select distinct ?p where {?s ?p ?o} LIMIT 25000
-#     # select distinct ?p where {?s ?p ?o} LIMIT 50000
-#     # select distinct ?p where {?s ?p ?o} LIMIT 100000
-#     # select distinct ?p where {?s ?p ?o} LIMIT 200000
-#     # select distinct ?p where {?s ?p ?o} LIMIT 500000
-#     # select distinct ?p where {?s ?p ?o} LIMIT 1000000
-
-# done < queries.txt

--- a/test/test-suite.sh
+++ b/test/test-suite.sh
@@ -20,21 +20,21 @@ while IFS=  read -r query
 do
     echo -e "${PURPLE}Query: ${YELLOW}${query} to Nginx${NC}" 
     nginx_start=$(date +%s)
-    for i in {1..10}
+    for i in {1..5}
     do
         curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query="$query" $nginx_url > /dev/null
     done
     nginx_stop=$(date +%s)   
-    nginxavg=$(echo "scale=4; ($nginx_stop - $nginx_start) / 10" | bc -l)
+    nginxavg=$(echo "scale=4; ($nginx_stop - $nginx_start) / 5" | bc -l)
     
     echo -e "${PURPLE}Query: ${YELLOW}${query} to Virtuoso${NC}"
     virtuoso_start=$(date +%s)
-    for i in {1..10}
+    for i in {1..5}
     do
         curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query="$query" $virtuoso_url > /dev/null
     done
     virtuoso_stop=$(date +%s)   
-    virtuosoavg=$(echo "scale=4; ($virtuoso_stop - $virtuoso_start) / 10" | bc -l)
+    virtuosoavg=$(echo "scale=4; ($virtuoso_stop - $virtuoso_start) / 5" | bc -l)
 
     decrease=$(echo "scale=4; $virtuosoavg - $nginxavg" | bc -l)
     perc_decrease=$(echo "scale=4; $decrease / $virtuosoavg * 100" | bc -l)   

--- a/test/test-suite.sh
+++ b/test/test-suite.sh
@@ -20,21 +20,21 @@ while IFS=  read -r query
 do
     echo -e "${PURPLE}Query: ${YELLOW}${query} to Nginx${NC}" 
     nginx_start=$(date +%s)
-    for i in {1..5}
+    for i in {1..10}
     do
         curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query="$query" $nginx_url > /dev/null
     done
     nginx_stop=$(date +%s)   
-    nginxavg=$(echo "scale=4; ($nginx_stop - $nginx_start) / 5" | bc -l)
+    nginxavg=$(echo "scale=4; ($nginx_stop - $nginx_start) / 10" | bc -l)
     
     echo -e "${PURPLE}Query: ${YELLOW}${query} to Virtuoso${NC}"
     virtuoso_start=$(date +%s)
-    for i in {1..5}
+    for i in {1..10}
     do
         curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query="$query" $virtuoso_url > /dev/null
     done
     virtuoso_stop=$(date +%s)   
-    virtuosoavg=$(echo "scale=4; ($virtuoso_stop - $virtuoso_start) / 5" | bc -l)
+    virtuosoavg=$(echo "scale=4; ($virtuoso_stop - $virtuoso_start) / 10" | bc -l)
 
     decrease=$(echo "scale=4; $virtuosoavg - $nginxavg" | bc -l)
     perc_decrease=$(echo "scale=4; $decrease / $virtuosoavg * 100" | bc -l)   

--- a/test/test-suite.sh
+++ b/test/test-suite.sh
@@ -18,7 +18,7 @@ echo -e "${RED}REMOTE VIRTUOSO PROXY: ${GREEN} ${virtuoso_url}${NC}"
 
 while IFS=  read -r query
 do
-    echo -e "${PURPLE}Query: ${YELLOW}${query} to Nginx" 
+    echo -e "${PURPLE}Query: ${YELLOW}${query} to Nginx${NC}" 
     nginx_start=$(date +%s)
     for i in {1..10}
     do
@@ -27,7 +27,7 @@ do
     nginx_stop=$(date +%s)   
     nginxavg=$(echo "scale=4; ($nginx_stop - $nginx_start) / 10" | bc -l)
     
-    echo -e "Query: ${query} to Virtuoso"
+    echo -e "${PURPLE}Query: ${YELLOW}${query} to Virtuoso${NC}"
     virtuoso_start=$(date +%s)
     for i in {1..10}
     do

--- a/test/test-suite.sh
+++ b/test/test-suite.sh
@@ -6,7 +6,7 @@ YELLOW='\033[1;33m'
 PURPLE='\033[1;35m'
 NC='\033[0m' # No Color
 
-remote_ip="http://143.233.226.61"
+remote_ip=""
 remote_path="sparql"
 nginx_url="${remote_ip}:443/${remote_path}"
 virtuoso_url="${remote_ip}:8890/${remote_path}"

--- a/test/test-suite.sh
+++ b/test/test-suite.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+PURPLE='\033[1;35m'
+NC='\033[0m' # No Color
+
+remote_ip=""
+remote_path="sparql"
+nginx_url="${remote_ip}:<nginx_port>/${remote_path}"
+virtuoso_url="${remote_ip}:<virtuoso_port>/${remote_path}"
+
+
+echo -e "${RED}REMOTE NGINX PROXY: ${GREEN} ${nginx_url}${NC}"
+echo -e "${RED}REMOTE VIRTUOSO PROXY: ${GREEN} ${virtuoso_url}${NC}"
+
+while read query; do
+    echo -e "${PURPLE}query: ${YELLOW} ${query}${NC}" 
+    nginxtime=$(TIMEFORMAT=%R; time (for i in {1..10}; do curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query='${query}' ${nginx_url} > /dev/null; sleep 0.5; done) 2>&1 1>/dev/null)
+    virtuosotime=$(TIMEFORMAT=%R; time (for i in {1..10; do curl -s -w '\n' -XPOST -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode query='${query}' ${virtuoso_url} > /dev/null; sleep 0.5; done) 2>&1 1>/dev/null)
+
+    nginxavg=$(echo "scale=4; $nginxtime / 10" | bc -l)
+    virtuosoavg=$(echo "scale=4; $virtuosotime / 10" | bc -l)
+
+    decrease=$(echo "scale=4; $virtuosoavg - $nginxavg" | bc -l)
+    perc_decrease=$(echo "$decrease / $virtuosoavg * 100" | bc -l)
+
+    echo -e "\t${PURPLE}avg nginx proxy time (15 calls): ${YELLOW} ${nginxavg}${NC}"
+    echo -e "\t${PURPLE}avg virtuoso time (15 calls): ${YELLOW} ${virtuosoavg}${NC}"
+    echo -e "\t\t${PURPLE}nginx calls compared to virtuoso are ${YELLOW} ${perc_decrease} % faster. ${NC}"
+done < queries.txt
+
+

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 curl --data-urlencode query=' select distinct ?type where { ?thing a ?type } limit 1 ' http://sparql.data.vlaanderen.be
 
 curl --verbose --data-urlencode query=' PREFIX adres: <http://data.vlaanderen.be/ns/adres#> PREFIX mu: <http://mu.semte.ch/vocabularies/core/> SELECT ((COUNT (DISTINCT ?uuid)) AS ?count) WHERE { GRAPH <http://data.vlaanderen.be/id/dataset/CRAB> { ?s mu:uuid ?uuid; a adres:Adres.  } } '  http://sparql.data.vlaanderen.be


### PR DESCRIPTION
Results of a local test:

Division by 0 errors are due to way too fast execution on nginx (under 1 second)

```sh
REMOTE NGINX PROXY:  http://localhost:443/sparql
REMOTE VIRTUOSO PROXY:  http://localhost:8890/sparql
Query: select distinct ?s where { ?s ?p ?o. ?p a ?pt. ?o a ?ot. } LIMIT 1000 to Nginx
Query: select distinct ?s where { ?s ?p ?o. ?p a ?pt. ?o a ?ot. } LIMIT 1000 to Virtuoso
Runtime error (func=(main), adr=9): Divide by zero
        avg nginx proxy time (10 calls):  0
        avg virtuoso time (10 calls):  0
                nginx calls compared to virtuoso are   % faster. 
Query: select distinct ?p where { ?s ?p ?o . } LIMIT 50000 to Nginx
Query: select distinct ?p where { ?s ?p ?o . } LIMIT 50000 to Virtuoso
        avg nginx proxy time (10 calls):  0
        avg virtuoso time (10 calls):  3.6000
                nginx calls compared to virtuoso are  100.0000 % faster. 
Query: select distinct ?p where { ?s ?p ?o . } LIMIT 100000 to Nginx
Query: select distinct ?p where { ?s ?p ?o . } LIMIT 100000 to Virtuoso
        avg nginx proxy time (10 calls):  0
        avg virtuoso time (10 calls):  3.5000
                nginx calls compared to virtuoso are  100.0000 % faster. 
Query: select distinct ?p where { ?s ?p ?o . } LIMIT 200000 to Nginx
Query: select distinct ?p where { ?s ?p ?o . } LIMIT 200000 to Virtuoso
        avg nginx proxy time (10 calls):  0
        avg virtuoso time (10 calls):  3.5000
                nginx calls compared to virtuoso are  100.0000 % faster. 
Query: select distinct ?p where { ?s ?p ?o . } LIMIT 500000 to Nginx
Query: select distinct ?p where { ?s ?p ?o . } LIMIT 500000 to Virtuoso
        avg nginx proxy time (10 calls):  .4000
        avg virtuoso time (10 calls):  3.7000
                nginx calls compared to virtuoso are  89.1800 % faster. 
Query: select distinct ?s count(?o) where { ?s a ?o . } group by ?s LIMIT 1000 to Nginx
Query: select distinct ?s count(?o) where { ?s a ?o . } group by ?s LIMIT 1000 to Virtuoso
        avg nginx proxy time (10 calls):  .5000
        avg virtuoso time (10 calls):  4.1000
                nginx calls compared to virtuoso are  87.8000 % faster. 
Query: select distinct ?s count(?o) where { ?s a ?o . } group by ?s LIMIT 5000 to Nginx
Query: select distinct ?s count(?o) where { ?s a ?o . } group by ?s LIMIT 5000 to Virtuoso
        avg nginx proxy time (10 calls):  .5000
        avg virtuoso time (10 calls):  4.0000
                nginx calls compared to virtuoso are  87.5000 % faster. 
Query: select distinct ?s count(?o) where { ?s a ?o . } group by ?s LIMIT 10000 to Nginx
Query: select distinct ?s count(?o) where { ?s a ?o . } group by ?s LIMIT 10000 to Virtuoso
        avg nginx proxy time (10 calls):  .4000
        avg virtuoso time (10 calls):  3.8000
                nginx calls compared to virtuoso are  89.4700 % faster. 
Query: select distinct ?name ?street ?pcode where { ?organization gr:legalName ?name ; vcard2006:hasAddress ?address . ?address vcard2006:street-address ?street ; vcard2006:postal-code ?pcode . } to Nginx
Query: select distinct ?name ?street ?pcode where { ?organization gr:legalName ?name ; vcard2006:hasAddress ?address . ?address vcard2006:street-address ?street ; vcard2006:postal-code ?pcode . } to Virtuoso
        avg nginx proxy time (10 calls):  0
        avg virtuoso time (10 calls):  .6000
                nginx calls compared to virtuoso are  100.0000 % faster. 
Query: PREFIX vcard2006: <http://www.w3.org/2006/vcard/ns#> PREFIX elodGeo: <http://linkedeconomy.org/geoOntology#> SELECT DISTINCT ?pcode ?nameMunicipality WHERE { ?organization vcard2006:hasAddress ?address . $
address vcard2006:postal-code ?pcode. ?codeArea elodGeo:postalCode ?pcode . ?municipality elodGeo:hasPart ?codeArea ; elodGeo:name ?nameMunicipality . filter langMatches(lang(?nameMunicipality),'en') } to Nginx
Query: PREFIX vcard2006: <http://www.w3.org/2006/vcard/ns#> PREFIX elodGeo: <http://linkedeconomy.org/geoOntology#> SELECT DISTINCT ?pcode ?nameMunicipality WHERE { ?organization vcard2006:hasAddress ?address . $
address vcard2006:postal-code ?pcode. ?codeArea elodGeo:postalCode ?pcode . ?municipality elodGeo:hasPart ?codeArea ; elodGeo:name ?nameMunicipality . filter langMatches(lang(?nameMunicipality),'en') } to Virtuo$
o
Runtime error (func=(main), adr=9): Divide by zero
        avg nginx proxy time (10 calls):  0
        avg virtuoso time (10 calls):  0
                nginx calls compared to virtuoso are   % faster. 
Query: SELECT distinct * WHERE { ?s rdfs:subClassOf ?p } to Nginx
Query: SELECT distinct * WHERE { ?s rdfs:subClassOf ?p } to Virtuoso
        avg nginx proxy time (10 calls):  0
        avg virtuoso time (10 calls):  .1000
                nginx calls compared to virtuoso are  100.0000 % faster. 
Query: prefix qb:<http://purl.org/linked-data/cube#> select distinct ?p ?o from <http://yourdatastories.eu/Diavgeia/DataCube> where { ?s a qb:Observation ; ?p ?o } to Nginx
Query: prefix qb:<http://purl.org/linked-data/cube#> select distinct ?p ?o from <http://yourdatastories.eu/Diavgeia/DataCube> where { ?s a qb:Observation ; ?p ?o } to Virtuoso
Runtime error (func=(main), adr=9): Divide by zero
        avg nginx proxy time (10 calls):  0
        avg virtuoso time (10 calls):  0
                nginx calls compared to virtuoso are   % faster.
```